### PR TITLE
Refactor the metal resource memory management

### DIFF
--- a/implementations/Metal/CMakeLists.txt
+++ b/implementations/Metal/CMakeLists.txt
@@ -17,6 +17,8 @@ set(AGPU_Metal_SOURCES
     framebuffer.hpp
     framebuffer.mm
     icd.cpp
+    implicit_resource_command_list.mm
+    implicit_resource_command_list.hpp
     pipeline_builder.hpp
     pipeline_builder.mm
     pipeline_state.hpp

--- a/implementations/Metal/command_list.mm
+++ b/implementations/Metal/command_list.mm
@@ -63,7 +63,6 @@ agpu_error AMtlCommandList::setShaderSignature(const agpu::shader_signature_ref 
 {
     currentShaderSignature = signature;
 
-    currentVertexBinding.reset();
     auto oldPipeline = currentPipeline;
     currentPipeline.reset();
 

--- a/implementations/Metal/common.hpp
+++ b/implementations/Metal/common.hpp
@@ -16,11 +16,6 @@ namespace AgpuMetal
 
 void printError(const char *format, ...);
 
-inline size_t alignedTo(size_t value, size_t alignment)
-{
-    return (value + alignment - 1) & (-alignment);
-}
-
 inline const char *duplicateCString(const char *cstring)
 {
     if(!cstring)

--- a/implementations/Metal/constants.hpp
+++ b/implementations/Metal/constants.hpp
@@ -78,6 +78,40 @@ inline MTLStencilOperation mapStencilOperation(agpu_stencil_operation operation)
     }
 }
 
+inline MTLResourceOptions mapBufferMemoryHeapType(agpu_memory_heap_type heapType)
+{
+    switch(heapType)
+    {
+    case AGPU_MEMORY_HEAP_TYPE_DEVICE_LOCAL:
+        return MTLResourceStorageModePrivate;
+    case AGPU_MEMORY_HEAP_TYPE_HOST_TO_DEVICE:
+        return MTLResourceStorageModeShared | MTLResourceCPUCacheModeWriteCombined;
+    case AGPU_MEMORY_HEAP_TYPE_CUSTOM:
+    case AGPU_MEMORY_HEAP_TYPE_HOST:
+    case AGPU_MEMORY_HEAP_TYPE_DEVICE_TO_HOST:  ;
+        return MTLResourceStorageModeShared | MTLResourceOptionCPUCacheModeDefault;
+    }
+}
+
+inline MTLStorageMode mapTextureStorageMode(agpu_memory_heap_type heapType)
+{
+    switch(heapType)
+    {
+    case AGPU_MEMORY_HEAP_TYPE_DEVICE_LOCAL:
+        return MTLStorageModePrivate;
+    case AGPU_MEMORY_HEAP_TYPE_HOST_TO_DEVICE:
+    case AGPU_MEMORY_HEAP_TYPE_CUSTOM:
+    case AGPU_MEMORY_HEAP_TYPE_HOST:
+    case AGPU_MEMORY_HEAP_TYPE_DEVICE_TO_HOST:
+#if TARGET_OS_IOS || TARGET_OS_TVOS
+        return MTLStorageModeShared;
+#endif
+#if TARGET_OS_OSX
+        return MTLStorageModeManaged;
+#endif
+    }
+}
+
 } // End of namespace AgpuMetal
 
 #endif //_AGPU_METAL_CONSTANTS_HPP

--- a/implementations/Metal/device.mm
+++ b/implementations/Metal/device.mm
@@ -22,11 +22,17 @@ namespace AgpuMetal
 {
 
 AMtlDevice::AMtlDevice()
+    :
+    implicitResourceUploadCommandList(*this),
+    implicitResourceReadbackCommandList(*this)
 {
 }
 
 AMtlDevice::~AMtlDevice()
 {
+    implicitResourceUploadCommandList.destroy();
+    implicitResourceReadbackCommandList.destroy();
+
     mainCommandQueue.reset();
     if(device)
         [device release];
@@ -49,6 +55,11 @@ agpu::device_ref AMtlDevice::open(agpu_device_open_info *openInfo)
     auto device = result.as<AMtlDevice> ();
     device->device = mtlDevice;
     device->mainCommandQueue = AMtlCommandQueue::create(result, mainCommandQueue);
+    
+    // Store a copy to in the implicit resource command lists.
+    device->implicitResourceUploadCommandList.commandQueue = device->mainCommandQueue;
+    device->implicitResourceReadbackCommandList.commandQueue = device->mainCommandQueue;
+
     return result;
 }
 

--- a/implementations/Metal/implicit_resource_command_list.hpp
+++ b/implementations/Metal/implicit_resource_command_list.hpp
@@ -1,0 +1,160 @@
+#ifndef AGPU_METAL_IMPLICIT_RESOURCE_COMMAND_LIST_HPP
+#define AGPU_METAL_IMPLICIT_RESOURCE_COMMAND_LIST_HPP
+
+#include "common.hpp"
+#include "../Common/utility.hpp"
+#import <Metal/Metal.h>
+#include <memory>
+#include <mutex>
+#include <algorithm>
+
+namespace AgpuMetal
+{
+using AgpuCommon::alignedTo;
+using AgpuCommon::nextPowerOfTwo;
+class AMtlDevice;
+
+class AMtlImplicitResourceSetupCommandList
+{
+public:
+    AMtlImplicitResourceSetupCommandList(AMtlDevice &cdevice);
+    ~AMtlImplicitResourceSetupCommandList();
+
+	void destroy();
+    
+    bool setupCommandBuffer();
+    bool submitCommandBuffer();
+
+    AMtlDevice &device;
+
+    std::mutex mutex;
+    agpu::command_queue_ref commandQueue;
+    id<MTLCommandBuffer> commandBuffer;
+
+protected:
+    id<MTLBuffer> createStagingBuffer(agpu_memory_heap_type heapType, size_t allocationSize);
+};
+
+template<agpu_memory_heap_type HT, size_t IC>
+class AMtlImplicitResourceStagingCommandList : public AMtlImplicitResourceSetupCommandList
+{
+public:
+    static constexpr agpu_memory_heap_type MemoryHeapType = HT;
+    static constexpr size_t InitialCapacity = IC;
+
+    AMtlImplicitResourceStagingCommandList(AMtlDevice &cdevice)
+        : AMtlImplicitResourceSetupCommandList(cdevice),
+        currentStagingBufferSize(0),
+        currentStagingBufferPointer(nullptr),
+        stagingBufferCapacity(0),
+        stagingBufferBasePointer(nullptr),
+        bufferHandle(nil)
+    {
+    }
+
+    ~AMtlImplicitResourceStagingCommandList()
+    {
+    }
+
+	void destroy()
+	{
+		if (bufferHandle)
+		{
+			[bufferHandle release];
+            bufferHandle = nil;
+		}
+		AMtlImplicitResourceSetupCommandList::destroy();
+	}
+
+    void ensureValidCPUStagingBuffer(size_t requiredSize, size_t requiredAlignment)
+    {
+        if(stagingBufferCapacity < requiredSize)
+        {
+            stagingBufferCapacity = nextPowerOfTwo(requiredSize);
+            stagingBufferCapacity = std::max(stagingBufferCapacity, size_t(InitialCapacity));
+            if(bufferHandle)
+            {
+                [bufferHandle release];
+                bufferHandle = nil;
+                stagingBufferBasePointer = nullptr;
+            }
+
+            bufferHandle = createStagingBuffer(MemoryHeapType, stagingBufferCapacity);
+            stagingBufferBasePointer = reinterpret_cast<uint8_t*> (bufferHandle.contents);
+        }
+
+        currentStagingBufferSize = requiredSize;
+        currentStagingBufferPointer = stagingBufferBasePointer;
+    }
+
+    bool uploadBufferData(id<MTLBuffer> destBuffer, size_t offset, size_t size)
+    {
+        id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer blitCommandEncoder];
+        [blitEncoder copyFromBuffer: bufferHandle sourceOffset: 0
+            toBuffer: destBuffer destinationOffset: offset
+            size: size];
+        [blitEncoder endEncoding];
+        
+        return true;
+    }
+
+    bool readbackBufferData(id<MTLBuffer> sourceBuffer, size_t offset, size_t size)
+    {
+        id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer blitCommandEncoder];
+        [blitEncoder copyFromBuffer: sourceBuffer sourceOffset: offset
+            toBuffer: bufferHandle destinationOffset: 0
+            size: size];
+        [blitEncoder endEncoding];
+        
+        return true;
+    }
+
+    bool uploadBufferDataToImage(id<MTLTexture> destImage, size_t level, size_t layerIndex, MTLRegion region, agpu_int pitch, agpu_int slicePitch)
+    {
+        id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer blitCommandEncoder];
+        [blitEncoder copyFromBuffer: bufferHandle
+                      sourceOffset: 0
+                 sourceBytesPerRow: pitch
+               sourceBytesPerImage: slicePitch
+                        sourceSize: region.size
+                         toTexture: destImage
+                  destinationSlice: layerIndex
+                  destinationLevel: level
+                 destinationOrigin: region.origin];
+        [blitEncoder endEncoding];
+        return true;
+    }
+
+    bool readbackImageDataToBuffer(id<MTLTexture> sourceImage, size_t level, size_t layerIndex, MTLRegion region, agpu_int pitch, agpu_int slicePitch)
+    {
+        id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer blitCommandEncoder];
+        [blitEncoder copyFromTexture:sourceImage
+                        sourceSlice: layerIndex
+                        sourceLevel: level
+                       sourceOrigin: region.origin
+                         sourceSize: region.size
+                           toBuffer: bufferHandle
+                  destinationOffset:0
+             destinationBytesPerRow:pitch
+           destinationBytesPerImage:slicePitch];
+        [blitEncoder endEncoding];
+        return true;
+    }
+    
+    size_t currentStagingBufferSize;
+    void *currentStagingBufferPointer;
+
+protected:
+
+    size_t stagingBufferCapacity;
+    uint8_t *stagingBufferBasePointer;
+
+    id<MTLBuffer> bufferHandle;
+};
+
+typedef AMtlImplicitResourceStagingCommandList<AGPU_MEMORY_HEAP_TYPE_HOST_TO_DEVICE, 2048*2048*4> AMtlImplicitResourceUploadCommandList;
+typedef AMtlImplicitResourceStagingCommandList<AGPU_MEMORY_HEAP_TYPE_DEVICE_TO_HOST, 2048*2048*4> AMtlImplicitResourceReadbackCommandList;
+
+} // End of namespace AgpuMetal
+
+#endif //AGPU_METAL_IMPLICIT_RESOURCE_COMMAND_LIST_HPP

--- a/implementations/Metal/implicit_resource_command_list.mm
+++ b/implementations/Metal/implicit_resource_command_list.mm
@@ -1,0 +1,48 @@
+#include "implicit_resource_command_list.hpp"
+#include "command_queue.hpp"
+#include "constants.hpp"
+
+namespace AgpuMetal
+{
+AMtlImplicitResourceSetupCommandList::AMtlImplicitResourceSetupCommandList(AMtlDevice &cdevice)
+    : device(cdevice)
+{
+    commandBuffer = nil;
+}
+
+AMtlImplicitResourceSetupCommandList::~AMtlImplicitResourceSetupCommandList()
+{
+}
+
+void AMtlImplicitResourceSetupCommandList::destroy()
+{
+    if(!commandBuffer)
+        return;
+
+    [commandBuffer release];
+    commandBuffer = nil;
+}
+
+bool AMtlImplicitResourceSetupCommandList::setupCommandBuffer()
+{
+    id<MTLCommandQueue> queue = commandQueue.as<AMtlCommandQueue> ()->handle;
+    commandBuffer = [queue commandBuffer];
+    return commandBuffer != nil;
+}
+
+bool AMtlImplicitResourceSetupCommandList::submitCommandBuffer()
+{
+    [commandBuffer commit];
+    [commandBuffer waitUntilCompleted];
+    [commandBuffer release];
+    commandBuffer = nil;
+    return true;
+}
+
+id<MTLBuffer> AMtlImplicitResourceSetupCommandList::createStagingBuffer(agpu_memory_heap_type heapType, size_t allocationSize)
+{
+    MTLResourceOptions options = mapBufferMemoryHeapType(heapType);
+    return [device.device newBufferWithLength: allocationSize options: options];
+}
+
+}

--- a/implementations/Vulkan/implicit_resource_command_list.cpp
+++ b/implementations/Vulkan/implicit_resource_command_list.cpp
@@ -98,6 +98,8 @@ AVkImplicitResourceSetupCommandList::~AVkImplicitResourceSetupCommandList()
 
 void AVkImplicitResourceSetupCommandList::destroy()
 {
+    if(commandPool == VK_NULL_HANDLE)
+        return;
 	vkDestroyCommandPool(device.device, commandPool, nullptr);
 	commandPool = VK_NULL_HANDLE;
 	commandBuffer = VK_NULL_HANDLE;

--- a/samples/samples-cpp/Sample2.cpp
+++ b/samples/samples-cpp/Sample2.cpp
@@ -53,6 +53,8 @@ public:
 
             // Create the pipeline builder
             auto pipelineBuilder = device->createPipelineBuilder();
+            pipelineBuilder->setRenderTargetFormat(0, ColorBufferFormat);
+            pipelineBuilder->setDepthStencilFormat(DepthStencilBufferFormat);
             pipelineBuilder->setShaderSignature(shaderSignature);
             pipelineBuilder->attachShader(vertexShader);
             pipelineBuilder->attachShader(fragmentShader);

--- a/samples/samples-cpp/Sample3.cpp
+++ b/samples/samples-cpp/Sample3.cpp
@@ -72,6 +72,8 @@ public:
 
             // Create the pipeline builder
             auto pipelineBuilder = device->createPipelineBuilder();
+            pipelineBuilder->setRenderTargetFormat(0, ColorBufferFormat);
+            pipelineBuilder->setDepthStencilFormat(DepthStencilBufferFormat);
             pipelineBuilder->setShaderSignature(shaderSignature);
             pipelineBuilder->attachShader(vertexShader);
             pipelineBuilder->attachShader(fragmentShader);

--- a/samples/samples-cpp/Sample4.cpp
+++ b/samples/samples-cpp/Sample4.cpp
@@ -53,6 +53,8 @@ public:
 
             // Create the pipeline builder
             auto pipelineBuilder = device->createPipelineBuilder();
+            pipelineBuilder->setRenderTargetFormat(0, ColorBufferFormat);
+            pipelineBuilder->setDepthStencilFormat(DepthStencilBufferFormat);
             pipelineBuilder->setShaderSignature(shaderSignature);
             pipelineBuilder->attachShader(vertexShader);
             pipelineBuilder->attachShader(fragmentShader);

--- a/samples/samples-cpp/SampleBase.cpp
+++ b/samples/samples-cpp/SampleBase.cpp
@@ -322,8 +322,8 @@ int SampleBase::main(int argc, const char **argv)
         return -1;
     }
 
-    swapChainCreateInfo.colorbuffer_format = AGPU_TEXTURE_FORMAT_B8G8R8A8_UNORM;
-    swapChainCreateInfo.depth_stencil_format = AGPU_TEXTURE_FORMAT_D32_FLOAT_S8X24_UINT;
+    swapChainCreateInfo.colorbuffer_format = ColorBufferFormat;
+    swapChainCreateInfo.depth_stencil_format = DepthStencilBufferFormat;
     swapChainCreateInfo.width = screenWidth;
     swapChainCreateInfo.height = screenHeight;
     swapChainCreateInfo.buffer_count = 3;

--- a/samples/samples-cpp/SampleBase.hpp
+++ b/samples/samples-cpp/SampleBase.hpp
@@ -16,6 +16,9 @@ std::string readWholeFile(const std::string &fileName);
 class AbstractSampleBase
 {
 public:
+    static const agpu_texture_format ColorBufferFormat = AGPU_TEXTURE_FORMAT_B8G8R8A8_UNORM;
+    static const agpu_texture_format DepthStencilBufferFormat = AGPU_TEXTURE_FORMAT_D32_FLOAT_S8X24_UINT;
+
     agpu_shader_ref compileShaderFromFile(const char *fileName, agpu_shader_type type);
     agpu_buffer_ref createImmutableVertexBuffer(size_t capacity, size_t vertexSize, void *initialData);
     agpu_buffer_ref createImmutableIndexBuffer(size_t capacity, size_t indexSize, void *initialData);


### PR DESCRIPTION
Do not invalidate the current vertex binding when changing the shader signature with the Metal backend.

I refactored the memory management of buffer and textures with the metal backend to use a single global staging/readback buffer for private transfers. This matches the behavior of the other backends.