### PR TITLE
added arm64 to CMAKE_OSX_ARCHITECTURES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.1)
 project(AGPU)
 
 if(APPLE)
-	set(CMAKE_OSX_ARCHITECTURES "x86_64")
+	set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
 endif()
 
 option(AGPU_BUILD_SAMPLES "Build AGPU Samples" OFF)


### PR DESCRIPTION
Added arm64 as an option to build a universal binary.

Tested with the examples on projects github page which all ran perfectly on an M1 Macbook Air on native m1 vm.

untested in OSX x86_64, but I would not expect any regressions due to this.